### PR TITLE
Fix unit tests for ApiKeyService

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,9 @@
-
-import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { MongooseModule } from '@nestjs/mongoose';
-import { ApiKey, ApiKeySchema } from './libs/api-key/entities/apikey.entity';
-import { ApiKeyController } from './libs/api-key/controllers/apikey.controller';
-import { ApiKeyService } from './libs/api-key/service/apiKey.service';
-
-
+import { Module } from "@nestjs/common";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { MongooseModule } from "@nestjs/mongoose";
+import { ApiKey, ApiKeySchema } from "./libs/api-key/entities/apikey.entity";
+import { ApiKeyController } from "./libs/api-key/controllers/apikey.controller";
+import { ApiKeyService } from "./libs/api-key/service/apiKey.service";
 
 @Module({
   imports: [
@@ -16,7 +13,7 @@ import { ApiKeyService } from './libs/api-key/service/apiKey.service';
     MongooseModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
-        uri: configService.get<string>('DB'),
+        uri: configService.get<string>("DB"),
         useNewUrlParser: true,
         useUnifiedTopology: true,
       }),

--- a/src/libs/api-key/controllers/apikey.controller.ts
+++ b/src/libs/api-key/controllers/apikey.controller.ts
@@ -20,10 +20,8 @@ import { ApiKeyService } from "../service/apiKey.service";
 import { CreateApiKeyDto } from "../dtos/create-apy-key.dto";
 import { validateKeyDto } from "../dtos/validatekey.dto";
 
-@ApiTags('Api-key')
-@Controller('api-key')
-
-
+@ApiTags("Api-key")
+@Controller("api-key")
 export class ApiKeyController {
   constructor(private readonly apiKeyService: ApiKeyService) {}
 

--- a/src/libs/api-key/service/apikey.service.spec.ts
+++ b/src/libs/api-key/service/apikey.service.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ApiKeyService } from "./apiKey.service";
+import { getModelToken } from "@nestjs/mongoose";
+import { NotFoundException } from "@nestjs/common";
+import { ApiKey } from "../entities/apikey.entity";
+
+describe("ApiKeyService", () => {
+  let service: ApiKeyService;
+
+  const mockApiKey = {
+    _id: "someId",
+    apiKey: "testKey",
+    limit: 100,
+    usageCount: 0,
+    isActive: true,
+    createdAt: null,
+    createBy: null,
+    updatedAt: null,
+    updateBy: null,
+    deletedAt: null,
+    deleteBy: null,
+    save: jest.fn().mockResolvedValue(this), // `this` hace referencia al objeto mockApiKey
+  };
+
+  const mockApiKeyModel = {
+    create: jest.fn().mockResolvedValue(mockApiKey),
+    findOne: jest.fn().mockResolvedValue(mockApiKey),
+    find: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnThis(), // `.limit` debe devolver el objeto mockeado para encadenar `.exec()`
+      exec: jest.fn().mockResolvedValue([mockApiKey]),
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeyService,
+        {
+          provide: getModelToken(ApiKey.name),
+          useValue: mockApiKeyModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeyService>(ApiKeyService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should validate an API key", async () => {
+    const result = await service.validateApiKey("testKey");
+    expect(result).toEqual(mockApiKey);
+  });
+
+  it("should throw NotFoundException if API key not found", async () => {
+    jest.spyOn(mockApiKeyModel, "findOne").mockResolvedValueOnce(null);
+    await expect(service.validateApiKey("invalidKey")).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/src/libs/middleware/http.filter.ts
+++ b/src/libs/middleware/http.filter.ts
@@ -3,8 +3,8 @@ import {
   Catch,
   ArgumentsHost,
   UnauthorizedException,
-} from '@nestjs/common';
-import { Request, Response } from 'express';
+} from "@nestjs/common";
+import { Request, Response } from "express";
 
 @Catch(UnauthorizedException)
 export class UnauthorizedExceptionFilter implements ExceptionFilter {
@@ -19,7 +19,7 @@ export class UnauthorizedExceptionFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
-      message: exception.message || 'Unauthorized',
+      message: exception.message || "Unauthorized",
     });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,33 +1,29 @@
-
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
-import { ConfigService } from '@nestjs/config';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-
-
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+import { ConfigService } from "@nestjs/config";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // Configuración de variables de entorno
   const configService = app.get(ConfigService);
-  const port = configService.get<number>('PORT') || 3000;
+  const port = configService.get<number>("PORT") || 3000;
 
   // Configuración de CORS
   app.enableCors();
 
   // Configuración de Swagger
   const config = new DocumentBuilder()
-    .setTitle('API Key Management')
-    .setDescription('API for managing API keys')
-    .setVersion('1.0')
+    .setTitle("API Key Management")
+    .setDescription("API for managing API keys")
+    .setVersion("1.0")
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup("api", app, document);
 
   await app.listen(port);
   console.log(`Application is running on: http://localhost:3000/api  `);
-
 }
 
 bootstrap();


### PR DESCRIPTION
- Reorganized `mockApiKey` declaration to avoid scope issues.
- Updated `mockApiKeyModel` to properly mock Mongoose methods including `find` and `limit`.
- Added necessary adjustments to ensure `find` returns an object with `limit` and `exec` methods.
- Improved tests to check for `NotFoundException` and proper validation of API keys."