### PR TITLE
test: add unit tests for ApiKeyController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
+        "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
@@ -2064,6 +2065,15 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/src/libs/api-key/controllers/apikey.controller.spec.ts
+++ b/src/libs/api-key/controllers/apikey.controller.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ApiKeyController } from "./apikey.controller";
+import { ApiKeyService } from "../service/apiKey.service";
+import { CreateApiKeyDto } from "../dtos/create-apy-key.dto";
+import { InternalServerErrorException } from "@nestjs/common";
+
+describe("ApiKeyController", () => {
+  let controller: ApiKeyController;
+  let service: ApiKeyService;
+
+  const mockApiKey = {
+    _id: "someId",
+    apiKey: "testKey",
+    limit: 100,
+    usageCount: 0,
+    isActive: true,
+    createdAt: null,
+    createBy: null,
+    updatedAt: null,
+    updateBy: null,
+    deletedAt: null,
+    deleteBy: null,
+  };
+
+  const mockApiKeyService = {
+    create: jest.fn().mockResolvedValue(mockApiKey),
+    validateApiKey: jest.fn().mockResolvedValue(mockApiKey),
+    getApiKeys: jest.fn().mockResolvedValue([mockApiKey]),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ApiKeyController],
+      providers: [
+        {
+          provide: ApiKeyService,
+          useValue: mockApiKeyService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ApiKeyController>(ApiKeyController);
+    service = module.get<ApiKeyService>(ApiKeyService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("create", () => {
+    it("should create a new API key", async () => {
+      const createApiKeyDto: CreateApiKeyDto = {
+        apiKey: "testKey",
+        limit: 100,
+        usageCount: 0,
+      };
+      await expect(controller.create(createApiKeyDto)).resolves.toEqual(
+        mockApiKey,
+      );
+      expect(service.create).toHaveBeenCalledWith(createApiKeyDto);
+    });
+
+    it("should handle InternalServerErrorException", async () => {
+      jest
+        .spyOn(service, "create")
+        .mockRejectedValueOnce(new InternalServerErrorException());
+      const createApiKeyDto: CreateApiKeyDto = {
+        apiKey: "testKey",
+        limit: 100,
+        usageCount: 0,
+      };
+      await expect(controller.create(createApiKeyDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe("validateApiKey", () => {
+    it("should validate an API key", async () => {
+      const apiKey = "testKey";
+      await expect(controller.validateApiKey(apiKey)).resolves.toEqual(
+        mockApiKey,
+      );
+      expect(service.validateApiKey).toHaveBeenCalledWith(apiKey);
+    });
+
+    it("should handle InternalServerErrorException", async () => {
+      jest
+        .spyOn(service, "validateApiKey")
+        .mockRejectedValueOnce(new InternalServerErrorException());
+      const apiKey = "invalidKey";
+      await expect(controller.validateApiKey(apiKey)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe("getApiKeys", () => {
+    it("should get a list of API keys", async () => {
+      const limit = 10;
+      const type = "testType";
+      await expect(controller.getApiKeys(limit, type)).resolves.toEqual([
+        mockApiKey,
+      ]);
+      expect(service.getApiKeys).toHaveBeenCalledWith(limit, type);
+    });
+
+    it("should handle InternalServerErrorException", async () => {
+      jest
+        .spyOn(service, "getApiKeys")
+        .mockRejectedValueOnce(new InternalServerErrorException());
+      const limit = 10;
+      const type = "invalidType";
+      await expect(controller.getApiKeys(limit, type)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Added tests for ApiKeyController's create, validateApiKey, and getApiKeys methods.
- Mocked ApiKeyService to simulate responses and exceptions.
- Added tests to handle successful operations and exceptions.